### PR TITLE
Map Group objects on group->get() method

### DIFF
--- a/src/Group/GroupService.php
+++ b/src/Group/GroupService.php
@@ -27,7 +27,7 @@ class GroupService extends \JiraRestApi\JiraClient
         $this->log->addInfo("Result=\n".$ret);
 
         return $this->json_mapper->map(
-                json_decode($ret), new User()
+                json_decode($ret), new Group()
         );
     }
 


### PR DESCRIPTION
Fixes
    Class 'JiraRestApi\Group\User' not found in lesstif/php-jira-rest-client/src/Group/GroupService.php:30